### PR TITLE
Fix SIGSEGV when encoding 1- or 2-byte data

### DIFF
--- a/Base64/Base64.m
+++ b/Base64/Base64.m
@@ -108,7 +108,7 @@
     
     NSUInteger i;
     NSUInteger outputLength = 0;
-    for (i = 0; i < inputLength - 2; i += 3)
+    for (i = 0; i + 2 < inputLength; i += 3)
     {
         outputBytes[outputLength++] = lookup[(inputBytes[i] & 0xFC) >> 2];
         outputBytes[outputLength++] = lookup[((inputBytes[i] & 0x03) << 4) | ((inputBytes[i + 1] & 0xF0) >> 4)];


### PR DESCRIPTION
Fix bug introduced by 4062db26 (arm64 support), which switched from signed to unsigned counters. It broke the for loop for small inputLength, since the comparison we did (0 < 1lu - 2lu) required signed integers.
