### PR TITLE
Fix warning

### DIFF
--- a/Base64/Base64.m
+++ b/Base64/Base64.m
@@ -49,8 +49,10 @@
     if (![string length]) return nil;
     
     NSData *decoded = nil;
+
     
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_9 || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+    #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_9 || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
     
     if (![NSData instancesRespondToSelector:@selector(initWithBase64EncodedString:options:)])
     {
@@ -58,6 +60,7 @@
     }
     else
     
+    #endif
 #endif
         
     {
@@ -73,7 +76,8 @@
     
     NSString *encoded = nil;
     
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_9 || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+    #if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_9 || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_7_0
     
     if (![NSData instancesRespondToSelector:@selector(base64EncodedStringWithOptions:)])
     {
@@ -81,6 +85,7 @@
     }
     else
     
+    #endif
 #endif
     
     {


### PR DESCRIPTION
Warning "'base64Encoding' is deprecated: first deprecated in iOS 7.0" in iOS 8.1 fixed.
